### PR TITLE
Fixing link to the Bill of Materials

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -4,7 +4,7 @@
 
 
 ## Before you begin:
-Printing Out the [Bill of Materials (BOM)](../BOM/BOM_Master.xlsx) is helpful as a reference. The descriptions it contains help distinguish between parts.
+Printing Out the [Bill of Materials (BOM)](./BOM/BOM_MASTER.xlsx) is helpful as a reference. The descriptions it contains help distinguish between parts.
 Download the CAD documents from [here](CAD/GrabCAD) to be viewed in e-drawings-viewer.
 
 ## Submodule Build Instructions


### PR DESCRIPTION
Link to the Bill of Materials pointed to a 404. Updated it to point to the correct address.
Changed from "../BOM/BOM_Master.xls" to "./BOM/BOM_MASTER.xls"